### PR TITLE
Migration of operator-utils away from master

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,5 +75,5 @@ required = [
     non-go = false
 
 [[constraint]]
-  branch = "master"
+  branch = "main"
   name = "github.com/RHsyseng/operator-utils"


### PR DESCRIPTION
Hi! I'm one of the maintainers for the RHsyseng/operator-utils library included as a dependency of your project. I see that it's been some time since this project has been updated, but for the sake of inclusivity, I'm reaching out to let you know that our project is migrating away from the "master" branch terminology to align with Red Hat's initiative [to do away with problematic language](https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language). As such, I'm submitting this PR to align your project with the new "main" branch terminology we're now using. Thanks for your time!